### PR TITLE
Add chromatic scale to scales.json

### DIFF
--- a/packages/scale/scales.json
+++ b/packages/scale/scales.json
@@ -1,4 +1,5 @@
 {
+  "chromatic": [ "1P 2m 2M 3m 3M 4P 4A 5P 6m 6M 7m 7M" ],
   "lydian": [ "1P 2M 3M 4A 5P 6M 7M" ],
   "major": [ "1P 2M 3M 4P 5P 6M 7M" , [ "ionian" ] ],
   "mixolydian": [ "1P 2M 3M 4P 5P 6M 7m" , [ "dominant" ] ],


### PR DESCRIPTION
For the sake of completeness I thought this would be part of the scales, correct me if I'm wrong :)
And I'm not sure if in this case 4A or 5d applies for the tritone note.

cheers!