### PR TITLE
Update tonal.fretboard README and set some defaults to freboard.chordShapes()

### DIFF
--- a/packages/incubator/fretboard/README.md
+++ b/packages/incubator/fretboard/README.md
@@ -28,6 +28,9 @@ fret numbers</p>
 <dt><a href="#scale">scale(tuning, scale, first, last)</a> ⇒ <code>Array</code></dt>
 <dd><p>Build a fretboard only showing the notes for the given scale.</p>
 </dd>
+<dt><a href="#chordShapes">chordShapes(tuning, notes, first, last, span)</a> ⇒ <code>Array</code></dt>
+<dd><p>Build an array of reachable chord shapes based on given notes and tuning.</p>
+</dd>
 </dl>
 
 <a name="tuning"></a>
@@ -107,3 +110,19 @@ Build a fretboard only showing the notes for the given scale.
 | scale | <code>String</code> &#124; <code>Array</code> | the scale notes |
 | first | <code>Integer</code> | the first fret number |
 | last | <code>Integer</code> | the last fret number |
+
+<a name="chordShapes"></a>
+
+## chordShapes(tuning, notes, first, last, span) ⇒ <code>Array</code>
+Build an array of reachable chord shapes based on given notes and tuning.
+
+**Kind**: global function  
+**Returns**: <code>Array</code> - An array of arrays, one for each possible shape.
+
+| Param | Type | Description |
+| --- | --- | --- |
+| tuning | <code>String</code> &#124; <code>Array</code> | the tuning name or notes |
+| notes | <code>Array</code> | an array of chord notes |
+| first | <code>Integer</code> | the first fret number |
+| last | <code>Integer</code> | the last fret number |
+| span | <code>Integer</code> | how many frets to include per position |

--- a/packages/incubator/fretboard/index.js
+++ b/packages/incubator/fretboard/index.js
@@ -136,9 +136,9 @@ export function chordShapes (tuning, notes, first, last, span) {
     })
   })
 
-  // Remove null and neighboring duplicate arrays
+  // Remove null, neighboring duplicate arrays, and arrays with a only one non-null value
   return positions.filter(function (position, i) {
-    if (!compact(position).length) return false
+    if (compact(position).length < 2) return false
     return i === 0 ? position : positions[i].toString() !== positions[i - 1].toString()
   })
 }

--- a/packages/incubator/fretboard/index.js
+++ b/packages/incubator/fretboard/index.js
@@ -102,12 +102,17 @@ export function scale (tuning, scale, first, last) {
  * Build an array of reachable chord shapes based on given notes and tuning.
  * @param {String|Array} tuning - the tuning name or notes
  * @param {Array} notes - an array of chord notes
- * @param {Integer} first - the first fret number
- * @param {Integer} last - the last fret number
- * @param {Integer} span - how many frets to include per position
+ * @param {Integer} first - the first fret number.  Default 0.
+ * @param {Integer} last - the last fret number.  Default 12.
+ * @param {Integer} span - how many frets to include per position.  Default 4.
  * @return {Array} An array of arrays, one for each possible shape.  Element index is string number [ '0', '2', '2', '1', '0', '0' ]
  */
 export function chordShapes (tuning, notes, first, last, span) {
+  // Set defaults
+  first = first || 0;
+  last = last || 12;
+  span = span || 4;
+
   var fretboard = scale(tuning, notes, first, last)
   var positions = []
 

--- a/packages/incubator/fretboard/test/fretboard.test.js
+++ b/packages/incubator/fretboard/test/fretboard.test.js
@@ -33,14 +33,18 @@ describe('tonal-fretboard', () => {
 
   test('chordShapes', () => {
     expect(fr.chordShapes('guitar', [], 0, 5, 3)).toEqual([])
-    expect(fr.chordShapes('guitar', ['G'], 0, 5, 3)).toEqual([ [ null, null, null, '0', null, null ],
-    [ '3', null, null, null, null, '3' ],
-    [ '3', null, '5', null, null, '3' ],
-    [ null, null, '5', null, null, null ] ])
-    expect(fr.chordShapes('guitar', ['E', 'G#', 'B'], 0, 5, 3)).toEqual([ [ '0', '2', '2', '1', '0', '0' ],
-    [ null, '2', '2', '1', null, null ],
-    [ '4', '2', '2', '4', null, '4' ],
-    [ '4', null, null, '4', '5', '4' ],
-    [ null, null, null, null, '5', null ] ])
+    expect(fr.chordShapes('guitar', ['G'], 0, 5, 3)).toEqual(
+    [
+      [ '3', null, null, null, null, '3' ],
+      [ '3', null, '5', null, null, '3' ]
+    ])
+
+    expect(fr.chordShapes('guitar', ['E', 'G#', 'B'], 0, 5, 3)).toEqual(
+    [ 
+      [ '0', '2', '2', '1', '0', '0' ],
+      [ null, '2', '2', '1', null, null ],
+      [ '4', '2', '2', '4', null, '4' ],
+      [ '4', null, null, '4', '5', '4' ] 
+    ])
   })
 })


### PR DESCRIPTION
These default arguments are reasonable for most cases and makes it so you don't need a long list or arguments every time the function is called.

Also exclude shapes with only a single note.