### PR TITLE
Fix `Note.midi`

### DIFF
--- a/extensions/abc-notation/package.json
+++ b/extensions/abc-notation/package.json
@@ -3,14 +3,10 @@
   "version": "1.1.2",
   "description": "Conversion between notes in ABC and scientific notation",
   "repository": "https://github.com/danigb/tonal/extensions/abc-notation",
-  "keywords": [
-    "note",
-    "ABC",
-    "notation",
-    "tonal"
-  ],
+  "keywords": ["note", "ABC", "notation", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -21,13 +17,9 @@
     "tonal-note": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/extensions/detect/package.json
+++ b/extensions/detect/package.json
@@ -3,16 +3,10 @@
   "version": "1.1.2",
   "description": "Find the name of pitch class sets",
   "repository": "https://github.com/danigb/tonal/extensions/detect",
-  "keywords": [
-    "pcset",
-    "detector",
-    "scale",
-    "chord",
-    "music theory",
-    "tonal"
-  ],
+  "keywords": ["pcset", "detector", "scale", "chord", "music theory", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -26,13 +20,9 @@
     "tonal-pcset": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/extensions/key/package.json
+++ b/extensions/key/package.json
@@ -3,13 +3,10 @@
   "version": "1.1.2",
   "description": "Conversion between key numbers and note names",
   "repository": "https://github.com/danigb/tonal/extensions/key",
-  "keywords": [
-    "note",
-    "key",
-    "tonal"
-  ],
+  "keywords": ["note", "key", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -22,13 +19,9 @@
     "tonal-note": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/extensions/range/package.json
+++ b/extensions/range/package.json
@@ -2,15 +2,11 @@
   "name": "tonal-range",
   "version": "1.1.2",
   "description": "Create ranges of notes",
-  "keywords": [
-    "music",
-    "theory",
-    "range",
-    "tonal"
-  ],
+  "keywords": ["music", "theory", "range", "tonal"],
   "repository": "https://github.com/danigb/tonal/extensions/range",
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -25,13 +21,9 @@
     "tonal-pcset": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/packages/array/package.json
+++ b/packages/array/package.json
@@ -3,12 +3,7 @@
   "version": "1.1.2",
   "description": "Tonal array utilities",
   "repository": "https://github.com/danigb/tonal/packages/array",
-  "keywords": [
-    "music",
-    "theory",
-    "array",
-    "tonal"
-  ],
+  "keywords": ["music", "theory", "array", "tonal"],
   "scripts": {
     "test": "jest --coverage"
   },
@@ -20,13 +15,9 @@
     "tonal-note": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/packages/chord/package.json
+++ b/packages/chord/package.json
@@ -3,14 +3,10 @@
   "version": "1.1.3",
   "description": "Music chords creation and manipulation",
   "repository": "https://github.com/danigb/tonal/packages/chord",
-  "keywords": [
-    "music",
-    "theory",
-    "chord",
-    "tonal"
-  ],
+  "keywords": ["music", "theory", "chord", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -24,13 +20,9 @@
     "tonal-pcset": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/packages/dictionary/package.json
+++ b/packages/dictionary/package.json
@@ -3,14 +3,10 @@
   "version": "1.1.2",
   "description": "Tonal key/value utilities",
   "repository": "https://github.com/danigb/tonal/packages/dictionary",
-  "keywords": [
-    "music",
-    "theory",
-    "dictionary",
-    "tonal"
-  ],
+  "keywords": ["music", "theory", "dictionary", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -23,13 +19,9 @@
     "tonal-pcset": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/packages/distance/package.json
+++ b/packages/distance/package.json
@@ -13,7 +13,8 @@
   ],
   "scripts": {
     "test": "jest --coverage",
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format grouped index.js > README.md"
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format grouped index.js > README.md"
   },
   "main": "build/es5.js",
   "module": "build/es6.js",
@@ -24,13 +25,9 @@
     "tonal-note": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/packages/interval/package.json
+++ b/packages/interval/package.json
@@ -3,14 +3,10 @@
   "version": "1.1.2",
   "description": "Music interval creation and manipulation",
   "repository": "https://github.com/danigb/tonal/packages/interval",
-  "keywords": [
-    "music",
-    "theory",
-    "interval",
-    "tonal"
-  ],
+  "keywords": ["music", "theory", "interval", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -18,8 +14,6 @@
   "author": "danigb",
   "license": "MIT",
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   }
 }

--- a/packages/note/index.js
+++ b/packages/note/index.js
@@ -103,7 +103,14 @@ const properties = str => {
   p.alt = p.acc[0] === "b" ? -p.acc.length : p.acc.length;
   p.oct = octStr.length ? +octStr : null;
   p.chroma = (SEMI[p.step] + p.alt + 120) % 12;
-  p.midi = p.oct !== null ? SEMI[p.step] + p.alt + 12 * (p.oct + 1) : null;
+  let midi = null;
+  if (p.oct !== null) {
+    const v = SEMI[p.step] + p.alt + 12 * (p.oct + 1);
+    if (v >= 0 && v <= 127) {
+      midi = v;
+    }
+  }
+  p.midi = midi;
   p.freq = midiToFreq(p.midi);
   return Object.freeze(p);
 };
@@ -181,7 +188,16 @@ export const pc = str => props(str).pc;
  * Note.midi(60) // => 60
  * @see midi.toMidi
  */
-export const midi = note => props(note).midi || +note || null;
+export const midi = note => {
+  if (typeof note !== "string" && typeof note !== "number") {
+    return null;
+  }
+  const n = +note;
+  if (n >= 0 && n <= 127) {
+    return n;
+  }
+  return props(note).midi;
+};
 
 /**
  * Get the frequency from midi number

--- a/packages/note/package.json
+++ b/packages/note/package.json
@@ -3,14 +3,10 @@
   "version": "1.1.2",
   "repository": "https://github.com/danigb/tonal/packages/note",
   "description": "Parse and manipulate music notes in scientific notation",
-  "keywords": [
-    "note",
-    "music",
-    "theory",
-    "tonal"
-  ],
+  "keywords": ["note", "music", "theory", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -19,8 +15,6 @@
   "author": "danigb",
   "license": "MIT",
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   }
 }

--- a/packages/note/test/note.spec.js
+++ b/packages/note/test/note.spec.js
@@ -87,9 +87,12 @@ describe("tonal-note", () => {
   });
 
   test("midi", () => {
-    const midis = "c4 d4 e4 f4 g4 a4 b4 c4".split(" ").map(note.midi);
-    expect(midis).toEqual([60, 62, 64, 65, 67, 69, 71, 60]);
+    const midis = "c4 d4 e4 f4 g4 a4 b4 c4 c-1 c-2".split(" ").map(note.midi);
+    expect(midis).toEqual([60, 62, 64, 65, 67, 69, 71, 60, 0, null]);
     expect(note.midi("C")).toBe(null);
+    expect(note.midi("bla")).toBe(null);
+    expect(note.midi(true)).toBe(null);
+    expect(note.midi(false)).toBe(null);
   });
 
   test("fromMidi", () => {
@@ -102,10 +105,13 @@ describe("tonal-note", () => {
     );
   });
 
-  test("midi accepts numbers", () => {
+  test("midi accepts valid MIDI note numbers", () => {
     expect(note.midi(60)).toBe(60);
     expect(note.midi("60")).toBe(60);
-    expect(note.midi("bla")).toBe(null);
+    expect(note.midi(0)).toBe(0);
+    expect(note.midi("0")).toBe(0);
+    expect(note.midi(-1)).toBe(null);
+    expect(note.midi(128)).toBe(null);
   });
 
   test("freq", () => {

--- a/packages/pcset/package.json
+++ b/packages/pcset/package.json
@@ -2,15 +2,10 @@
   "name": "tonal-pcset",
   "version": "1.1.2",
   "description": "Create and manipulate pitch class sets",
-  "keywords": [
-    "music",
-    "theory",
-    "pitch class",
-    "sets",
-    "tonal"
-  ],
+  "keywords": ["music", "theory", "pitch class", "sets", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -23,13 +18,9 @@
     "tonal-note": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/packages/scale/package.json
+++ b/packages/scale/package.json
@@ -3,14 +3,10 @@
   "version": "1.1.2",
   "description": "Music scales creation and manipulation",
   "repository": "https://github.com/danigb/tonal/packages/scale",
-  "keywords": [
-    "music",
-    "theory",
-    "scale",
-    "tonal"
-  ],
+  "keywords": ["music", "theory", "scale", "tonal"],
   "scripts": {
-    "docs": "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
+    "docs":
+      "jsdoc2md -d 1 --name-format --member-index-format list index.js > README.md",
     "test": "jest --coverage"
   },
   "main": "build/es5.js",
@@ -25,13 +21,9 @@
     "tonal-pcset": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }

--- a/packages/tonal/package.json
+++ b/packages/tonal/package.json
@@ -12,11 +12,7 @@
   "bugs": {
     "url": "https://github.com/danigb/tonal/issues"
   },
-  "keywords": [
-    "music",
-    "tonal",
-    "theory"
-  ],
+  "keywords": ["music", "tonal", "theory"],
   "author": "danigb",
   "license": "MIT",
   "dependencies": {
@@ -31,13 +27,9 @@
     "tonal-scale": "^1.1.2"
   },
   "babel": {
-    "presets": [
-      "es2015"
-    ]
+    "presets": ["es2015"]
   },
   "jest": {
-    "transformIgnorePatterns": [
-      "<rootDir>/node_modules/(?!tonal)"
-    ]
+    "transformIgnorePatterns": ["<rootDir>/node_modules/(?!tonal)"]
   }
 }


### PR DESCRIPTION
`Note.midi` currently returns `null` for inputs `0` and `"c-1"`, which is incorrect. Fixed to return `0`.

I'm not sure if the current behavior of returning numbers not in the range of 0 to 127, inclusive, is by design, but it doesn't seem correct to me. Only valid MIDI note numbers are now returned.

I also fixed other wonky behavior, such as `Note.midi(true)` returning `1`.

I apologize for the noise in the diff. It's the result of `npm run pretest`, which formats the code. I think `npm run format` needs to be run on master and checked in?

Thanks for the great lib, BTW. Enjoy using it :)